### PR TITLE
Add missing headers.

### DIFF
--- a/include/hareflow/logging.h
+++ b/include/hareflow/logging.h
@@ -3,6 +3,9 @@
 #include <functional>
 #include <shared_mutex>
 #include <string>
+#include <string_view>
+#include <mutex>
+#include <utility>
 
 #include <fmt/core.h>
 

--- a/src/client_impl.cpp
+++ b/src/client_impl.cpp
@@ -1,5 +1,6 @@
 #include "hareflow/detail/client_impl.h"
 
+#include <thread>
 #include <fmt/core.h>
 
 #include "hareflow/codec.h"


### PR DESCRIPTION
This project does not build on Ubuntu 22.04 because it names things without including the right headers.

<mutex> for unique_lock.
<string_view> for string_view.
<utility> for move and forward.

... and <thread> for std:thread:id