### PR TITLE
Fix compatibility with fmt 12.2.0

### DIFF
--- a/include/hareflow/detail/binary_buffer.h
+++ b/include/hareflow/detail/binary_buffer.h
@@ -6,7 +6,7 @@
 #include <string>
 
 #include <boost/asio.hpp>
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "hareflow/exceptions.h"
 #include "hareflow/types.h"

--- a/include/hareflow/logging.h
+++ b/include/hareflow/logging.h
@@ -7,7 +7,7 @@
 #include <mutex>
 #include <utility>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "hareflow/export.h"
 

--- a/integration/bench.cpp
+++ b/integration/bench.cpp
@@ -2,7 +2,7 @@
 #include <chrono>
 #include <future>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <gtest/gtest.h>
 
 #include "hareflow.h"

--- a/src/accumulator.cpp
+++ b/src/accumulator.cpp
@@ -1,6 +1,6 @@
 #include "hareflow/detail/accumulator.h"
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "hareflow/codec.h"
 #include "hareflow/detail/commands.h"

--- a/src/client_impl.cpp
+++ b/src/client_impl.cpp
@@ -1,7 +1,7 @@
 #include "hareflow/detail/client_impl.h"
 
 #include <thread>
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "hareflow/codec.h"
 #include "hareflow/logging.h"

--- a/src/exceptions.cpp
+++ b/src/exceptions.cpp
@@ -1,6 +1,6 @@
 #include "hareflow/exceptions.h"
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 namespace {
 

--- a/src/qpid_proton_codec.cpp
+++ b/src/qpid_proton_codec.cpp
@@ -1,6 +1,6 @@
 #include "hareflow/qpid_proton_codec.h"
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #ifdef _WIN32
 #    pragma warning(push)

--- a/src/stream_creator.cpp
+++ b/src/stream_creator.cpp
@@ -2,7 +2,7 @@
 
 #include <map>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "hareflow/exceptions.h"
 #include "hareflow/detail/client_impl.h"


### PR DESCRIPTION
## Problem

fmtlib/fmt deprecated `<fmt/core.h>` in commit [0007426](https://github.com/fmtlib/fmt/commit/0007426c2d8d22df6e56d3b4d109415242e683e0). Starting from fmt 12.2.0, using `<fmt/core.h>` causes compilation errors because the deprecated include is now opt-in only.

## Fix

Replace all `#include <fmt/core.h>` with `#include <fmt/format.h>`, which is the standard header in fmt 12.2.0+.